### PR TITLE
fix: Handle breaking change of Pulumi Terraform Bridge

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -39,7 +39,7 @@
     "skip_git_init": "no",
 
     "__terraform_bridge_version": "{{ get_latest_release_commit('pulumi-terraform-bridge') }}",
-    "__pulumi_sdk_version": "v3.66.0",
+    "__pulumi_sdk_version": "v3.81.0",
     "__pulumi_ctl_version": "{{ get_latest_release('pulumictl') }}",
     "__pulumi_java_version": "{{ get_latest_release('pulumi-java') }}",
     "__go_version_major": "{{ cookiecutter.go_version | version_major }}",

--- a/{{cookiecutter.provider}}/provider/go.mod
+++ b/{{cookiecutter.provider}}/provider/go.mod
@@ -5,7 +5,7 @@ go {{ cookiecutter.__go_version_major }}.{{ cookiecutter.__go_version_minor }}
 replace (
 	{% if cookiecutter.terraform_sdk_version != "plugin-framework" -%}
 	{% if cookiecutter.terraform_sdk_version == "2" -%}
-	github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20220725190814-23001ad6ec03
+	github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20230710100801-03a71d0fca3d
 	{% endif -%}
 	{% endif -%}
 	{% if cookiecutter.terraform_provider_package_name.startswith("internal") -%}

--- a/{{cookiecutter.provider}}/provider/shim/shim.go
+++ b/{{cookiecutter.provider}}/provider/shim/shim.go
@@ -21,9 +21,7 @@ import (
 	tf "github.com/hashicorp/terraform-plugin-framework/provider"
 )
 
-func NewProvider() func() tf.Provider {
-	return func() tf.Provider {
+func NewProvider() tf.Provider {
 		return provider.New()
-	}
 }
 {% endif -%}


### PR DESCRIPTION
This PR contains changes to handle the breaking change of the Pulumi Terraform Bridge Plugin Framework with version  v0.12.0 and onwards.

Fixes: #18