### PR TITLE
fix: build_nodejs target in Makefile

### DIFF
--- a/{{cookiecutter.provider}}/Makefile
+++ b/{{cookiecutter.provider}}/Makefile
@@ -59,7 +59,6 @@ build_nodejs:: install_plugins tfgen # build the node sdk
 	cd sdk/nodejs/ && \
         yarn install && \
         yarn run tsc && \
-		cp -R scripts/ bin && \
         cp ../../README.md ../../LICENSE package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 


### PR DESCRIPTION
fix({{cookiecutter.provider}}/Makefile): removed obsolete cp command from build_nodejs target

Closes: #25