### PR TITLE
fix: SDK go.mod file

### DIFF
--- a/{{cookiecutter.provider}}/sdk/go.mod
+++ b/{{cookiecutter.provider}}/sdk/go.mod
@@ -1,5 +1,5 @@
 module github.com/{{ cookiecutter.provider_github_organization }}/{{ cookiecutter.provider }}/sdk
 
-go 1.17
+go {{ cookiecutter.__go_version_major }}.{{ cookiecutter.__go_version_minor }}
 
-require github.com/pulumi/pulumi/sdk/v3 v3.38.0
+require github.com/pulumi/pulumi/sdk/v3 {{ cookiecutter.__pulumi_sdk_version }}


### PR DESCRIPTION
fix({{cookiecutter.provider}}/sdk/go.mod): generating go version and version of Pulumi SDK from Cookiecutter variables

Closes: #26