### PR TITLE
feat: Autogenerate provider resources mappings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: 'https://github.com/pre-commit/pre-commit-hooks'
-    rev: 'v4.4.0'
+    rev: 'v4.5.0'
     hooks:
       - id: 'check-added-large-files'
       - id: 'fix-byte-order-marker'
@@ -15,13 +15,13 @@ repos:
       - id: 'check-merge-conflict'
 
   - repo: 'https://github.com/adrienverge/yamllint.git'
-    rev: 'v1.29.0'
+    rev: 'v1.32.0'
     hooks:
       - id: 'yamllint'
         exclude: 'azure-pipelines.yml'
 
   - repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 23.10.1
     hooks:
       - id: black
 

--- a/README.md
+++ b/README.md
@@ -104,8 +104,11 @@ After the Cookiecutter template has created the new directory for the Pulumi
 provider, you can change to this directory and use the `make tfgen` command to
 check whether the Terraform provider has been referenced correctly.
 
-For guidance how to further develop the newly created Pulumi provider refer to
-`README-DEVELOPMENT.md` in the provider directory.
+> **Note**  
+> For guidance how to further develop the newly created Pulumi provider refer to
+> `README-DEVELOPMENT.md` in the provider directory especially how to map
+> resources and data sources from the upstream Terraform provider including the
+> possbility to autogenerate hose mappings.
 
 ## Parameter details
 

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -45,6 +45,10 @@
     "__go_version_major": "{{ cookiecutter.go_version | version_major }}",
     "__go_version_minor": "{{ cookiecutter.go_version | version_minor }}",
 
+    "_jinja2_env_vars": {
+        "lstrip_blocks": true,
+        "trim_blocks": true
+    },
     "_copy_without_render": [],
     "_extensions": [
         "local_extensions.LocalExtension"

--- a/local_extensions.py
+++ b/local_extensions.py
@@ -72,7 +72,7 @@ class LocalExtension(Extension):
         super().__init__(environment)
         environment.globals["get_latest_release"] = get_latest_release
         environment.globals["get_latest_release_commit"] = get_latest_release_commit
-        environment.tests["truthy"] = is_truthy
+        environment.filters["truthy"] = is_truthy
         environment.filters["capitalize"] = capitalize
         environment.filters["go_module_version"] = go_module_version
         environment.filters["go_module_name"] = go_module_name

--- a/{{cookiecutter.provider}}/.github/workflows/pull-request.yml
+++ b/{{cookiecutter.provider}}/.github/workflows/pull-request.yml
@@ -1,4 +1,4 @@
-{% raw -%}
+{% raw %}
 name: build
 
 on:

--- a/{{cookiecutter.provider}}/.github/workflows/release.yml
+++ b/{{cookiecutter.provider}}/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-{% raw -%}
+{% raw %}
 name: release
 
 on:

--- a/{{cookiecutter.provider}}/CONTRIBUTING.md
+++ b/{{cookiecutter.provider}}/CONTRIBUTING.md
@@ -5,11 +5,11 @@ We have a few tips and housekeeping items to help you get up and running.
 
 ## Code of Conduct
 
-Please make sure to read and observe our [Code of Conduct]({%- if cookiecutter.provider_github_organization.lower() == "pulumiverse" -%}
+Please make sure to read and observe our [Code of Conduct]({% if cookiecutter.provider_github_organization.lower() == "pulumiverse" %}
 https://github.com/pulumiverse/.github/blob/main/CODE_OF_CONDUCT.md
-{%- else -%}
+{% else %}
 ./CODE-OF-CONDUCT.md
-{%- endif -%}
+{% endif %}
 )
 
 ## Community Expectations

--- a/{{cookiecutter.provider}}/Makefile
+++ b/{{cookiecutter.provider}}/Makefile
@@ -108,6 +108,9 @@ help::
  	sed "s/\(.\+\):\s*\(.*\) #\s*\(.*\)/`printf "\033[93m"`\1`printf "\033[0m"`	\3 [\2]/" | \
  	expand -t20
 
+generate::
+	go generate provider/resources.go
+
 clean::
 	rm -rf sdk/{dotnet,nodejs,go,python} sdk/go.sum
 

--- a/{{cookiecutter.provider}}/docs/_index.md
+++ b/{{cookiecutter.provider}}/docs/_index.md
@@ -6,6 +6,6 @@ layout: overview
 
 The {{ cookiecutter.terraform_provider_name | capitalize }} provider for Pulumi can be used to provision any of the cloud resources available in {{ cookiecutter.terraform_provider_name | capitalize }}.
 
-{%- if cookiecutter.provider_category != "utility" -%}
+{% if cookiecutter.provider_category != "utility" %}
 The {{ cookiecutter.terraform_provider_name | capitalize }} provider must be configured with credentials to deploy and update resources in {{ cookiecutter.terraform_provider_name | capitalize }}.
-{%- endif -%}
+{% endif %}

--- a/{{cookiecutter.provider}}/go.work
+++ b/{{cookiecutter.provider}}/go.work
@@ -2,9 +2,9 @@ go 1.18
 
 use (
     ./provider
-    {%- if cookiecutter.terraform_provider_package_name.startswith("internal") %}
+    {% if cookiecutter.terraform_provider_package_name.startswith("internal") %}
     ./provider/shim
-    {%- endif %}
+    {% endif %}
     // ******
     // Add ./sdk folder when SDK has been published the first time
     // ./sdk

--- a/{{cookiecutter.provider}}/provider/cmd/pulumi-resource-{{ cookiecutter.terraform_provider_name }}/main.go
+++ b/{{cookiecutter.provider}}/provider/cmd/pulumi-resource-{{ cookiecutter.terraform_provider_name }}/main.go
@@ -17,17 +17,17 @@
 package main
 
 import (
-	{% if cookiecutter.terraform_sdk_version == "plugin-framework" -%}
+	{% if cookiecutter.terraform_sdk_version == "plugin-framework" %}
 	"context"
-	{% endif -%}
+	{% endif %}
 	_ "embed"
 
-	{% if cookiecutter.terraform_sdk_version != "plugin-framework" -%}
+	{% if cookiecutter.terraform_sdk_version != "plugin-framework" %}
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	"github.com/{{ cookiecutter.provider_github_organization }}/pulumi-{{ cookiecutter.terraform_provider_name }}/provider/pkg/version"
 	{% else %}
 	"github.com/pulumi/pulumi-terraform-bridge/pf/tfbridge"
-	{% endif -%}
+	{% endif %}
 	{{ cookiecutter.terraform_provider_name }} "github.com/{{ cookiecutter.provider_github_organization }}/pulumi-{{ cookiecutter.terraform_provider_name }}/provider"
 )
 
@@ -35,9 +35,9 @@ import (
 var pulumiSchema []byte
 
 func main() {
-	{% if cookiecutter.terraform_sdk_version != "plugin-framework" -%}
+	{% if cookiecutter.terraform_sdk_version != "plugin-framework" %}
 	tfbridge.Main("{{ cookiecutter.terraform_provider_name }}", version.Version, {{ cookiecutter.terraform_provider_name }}.Provider(), pulumiSchema)
-	{% else -%}
+	{% else %}
 	meta := tfbridge.ProviderMetadata{PackageSchema: pulumiSchema}
 	tfbridge.Main(context.Background(), "{{ cookiecutter.terraform_provider_name }}", {{ cookiecutter.terraform_provider_name }}.Provider(), meta)
 	{% endif %}

--- a/{{cookiecutter.provider}}/provider/cmd/pulumi-tfgen-{{ cookiecutter.terraform_provider_name }}/main.go
+++ b/{{cookiecutter.provider}}/provider/cmd/pulumi-tfgen-{{ cookiecutter.terraform_provider_name }}/main.go
@@ -16,18 +16,18 @@ package main
 
 import (
 	{{ cookiecutter.terraform_provider_name }} "github.com/{{ cookiecutter.provider_github_organization }}/pulumi-{{ cookiecutter.terraform_provider_name }}/provider"
-	{% if cookiecutter.terraform_sdk_version != "plugin-framework" -%}
+	{% if cookiecutter.terraform_sdk_version != "plugin-framework" %}
 	"github.com/{{ cookiecutter.provider_github_organization }}/pulumi-{{ cookiecutter.terraform_provider_name }}/provider/pkg/version"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen"
-	{% else -%}
+	{% else %}
 	"github.com/pulumi/pulumi-terraform-bridge/pf/tfgen"
-	{% endif -%}
+	{% endif %}
 )
 
 func main() {
-	{% if cookiecutter.terraform_sdk_version != "plugin-framework" -%}
+	{% if cookiecutter.terraform_sdk_version != "plugin-framework" %}
 	tfgen.Main("{{ cookiecutter.terraform_provider_name }}", version.Version, {{ cookiecutter.terraform_provider_name }}.Provider())
-	{% else -%}
+	{% else %}
 	tfgen.Main("{{ cookiecutter.terraform_provider_name }}", {{ cookiecutter.terraform_provider_name }}.Provider())
-	{% endif -%}
+	{% endif %}
 }

--- a/{{cookiecutter.provider}}/provider/generate.go
+++ b/{{cookiecutter.provider}}/provider/generate.go
@@ -1,0 +1,222 @@
+//go:build exclude
+
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/printer"
+	"go/token"
+	"log"
+	"os"
+	"os/exec"
+	"reflect"
+	"regexp"
+	"strings"
+)
+
+var (
+	rxMissingResource   = regexp.MustCompile(`TF resource "(\w+)" not`)
+	rxMissingDataSource = regexp.MustCompile(`TF data source "(\w+)" not`)
+)
+
+// addNewline is a hack to let us force a newline at a certain position. (https://github.com/mvdan/gofumpt/blob/master/format/format.go#L217)
+func addNewline(f *token.File, at token.Pos) {
+	offset := f.Offset(at)
+
+	field := reflect.ValueOf(f).Elem().FieldByName("lines")
+	n := field.Len()
+	lines := make([]int, 0, n+1)
+	for i := 0; i < n; i++ {
+		cur := int(field.Index(i).Int())
+		if offset == cur {
+			// This newline already exists; do nothing. Duplicate
+			// newlines can't exist.
+			return
+		}
+		if offset >= 0 && offset < cur {
+			lines = append(lines, offset)
+			offset = -1
+		}
+		lines = append(lines, cur)
+	}
+	if offset >= 0 {
+		lines = append(lines, offset)
+	}
+	if !f.SetLines(lines) {
+		panic(fmt.Sprintf("could not set lines to %v", lines))
+	}
+}
+
+func addKeyToMap(name, fnc string, pos token.Pos, kve *ast.KeyValueExpr) {
+	resExpr := ast.KeyValueExpr{
+		Key: &ast.BasicLit{
+			Kind:     token.STRING,
+			Value:    fmt.Sprintf("%q", name),
+			ValuePos: pos,
+		},
+		Value: &ast.CompositeLit{
+			Elts: []ast.Expr{
+				&ast.KeyValueExpr{
+					Key: ast.NewIdent("Tok"),
+					Value: &ast.CallExpr{
+						Fun: ast.NewIdent(fnc),
+						Args: []ast.Expr{
+							ast.NewIdent("mainMod"),
+							&ast.BasicLit{
+								Kind:  token.STRING,
+								Value: fmt.Sprintf("%q", name),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	kve.Value.(*ast.CompositeLit).Elts = append(kve.Value.(*ast.CompositeLit).Elts, &resExpr)
+}
+
+func main() {
+	fmt.Println("🧱 Building tfgen ...")
+	cmd := exec.Command("make", "-C", "..", "tfgen")
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, "PULUMI_SKIP_MISSING_MAPPING_ERROR=1")
+
+	r, _ := cmd.StderrPipe()
+	done := make(chan struct{})
+	scanner := bufio.NewScanner(r)
+
+	stderr := []string{}
+	missingResources := []string{}
+	missingDataSources := []string{}
+
+	go func() {
+		// Read line by line and process it
+		for scanner.Scan() {
+			line := scanner.Text()
+			stderr = append(stderr, line)
+
+			for i, m := range rxMissingResource.FindStringSubmatch(line) {
+				if i > 0 { // ignore initial match because it contains the complete line if the regex matches
+					fmt.Printf("✨ Missing resource %s\n", m)
+					missingResources = append(missingResources, m)
+				}
+			}
+
+			for i, m := range rxMissingDataSource.FindStringSubmatch(line) {
+				if i > 0 { // ignore initial match because it contains the complete line if the regex matches
+					fmt.Printf("✨ Missing data source %s\n", m)
+					missingDataSources = append(missingDataSources, m)
+				}
+			}
+
+		}
+
+		// We're all done, unblock the channel
+		done <- struct{}{}
+	}()
+
+	// Start the command and check for errors
+	err := cmd.Start()
+	if err != nil {
+		log.Fatalf("failed to start cmd: error(%T): %s", err, err)
+	}
+
+	// Wait for all output to be processed
+	<-done
+
+	// Wait for the command to finish
+	err = cmd.Wait()
+	if execErr := (&exec.ExitError{}); errors.As(err, &execErr) {
+		if execErr.ExitCode() != 2 {
+			log.Fatalf("🔥 Failed build tfgen failed with error(%T): %s", err, err)
+		} else if len(missingResources) == 0 && len(missingDataSources) == 0 {
+			log.Fatalf("🔥 Failed build tfgen with error(%T): %s\n", err, err, strings.Join(stderr, "\n"))
+		}
+	} else if err != nil {
+		log.Fatalf("🔥 Failed build tfgen with error(%T): %s", err, err)
+	}
+
+	if len(missingResources) == 0 && len(missingDataSources) == 0 {
+		fmt.Println("🌈 No missing resources or data sources found")
+		return
+	}
+
+	srcFile := "resources.go"
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, srcFile, nil, parser.ParseComments|parser.SkipObjectResolution)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var providerDecl *ast.CompositeLit
+	ast.Inspect(f, func(n ast.Node) bool {
+		switch x := n.(type) {
+		case *ast.AssignStmt:
+			if c, ok := x.Rhs[0].(*ast.CompositeLit); ok {
+				s, ok := c.Type.(*ast.SelectorExpr)
+				if ok && s.Sel.Name == "ProviderInfo" {
+					providerDecl = c
+					return false
+				}
+			}
+		}
+		return true
+	})
+
+	if providerDecl != nil {
+		fmt.Println("🎯 Adding missing resources and data sources ...")
+		for _, e := range providerDecl.Elts {
+			kve, ok := e.(*ast.KeyValueExpr)
+			if ok {
+				iterateItems := func(items []string) {
+					n := kve.Key.(*ast.Ident).Name
+					funcName := "make" + n[:len(n)-1]
+
+					var offset token.Pos
+					l := len(kve.Value.(*ast.CompositeLit).Elts)
+					if l == 0 {
+						offset = kve.Value.(*ast.CompositeLit).Rbrace - 7
+					} else {
+						offset = kve.Value.(*ast.CompositeLit).Elts[l-1].End()
+					}
+					f := fset.File(kve.Value.(*ast.CompositeLit).Rbrace - 7)
+					for i, r := range items {
+						pos := token.Pos(int(offset) + i)
+						addKeyToMap(r, funcName, pos, kve)
+						addNewline(f, pos)
+					}
+				}
+				switch kve.Key.(*ast.Ident).Name {
+				case "DataSources":
+					iterateItems(missingDataSources)
+				case "Resources":
+					iterateItems(missingResources)
+				}
+			}
+		}
+		io, err := os.Create(srcFile)
+		if err != nil {
+			log.Fatalf("🔥 Failed to open source file %s", err)
+		}
+		defer io.Close()
+
+		w := bufio.NewWriter(io)
+		err = printer.Fprint(w, fset, f)
+		if err != nil {
+			log.Fatal(err)
+		}
+		w.Flush()
+
+		fmt.Println("🚀 Formatting code ...")
+		cmd := exec.Command("go", "fmt", srcFile)
+		if err := cmd.Run(); err != nil {
+			log.Fatal("🔥 Failed formatting code with error(%T): %s", err, err)
+		}
+	} else {
+		log.Fatal("🔥 ProviderInfo declaration not found")
+	}
+}

--- a/{{cookiecutter.provider}}/provider/go.mod
+++ b/{{cookiecutter.provider}}/provider/go.mod
@@ -3,19 +3,19 @@ module github.com/{{ cookiecutter.provider_github_organization }}/{{ cookiecutte
 go {{ cookiecutter.__go_version_major }}.{{ cookiecutter.__go_version_minor }}
 
 replace (
-	{% if cookiecutter.terraform_sdk_version != "plugin-framework" -%}
-	{% if cookiecutter.terraform_sdk_version == "2" -%}
+	{% if cookiecutter.terraform_sdk_version != "plugin-framework" %}
+	{% if cookiecutter.terraform_sdk_version == "2" %}
 	github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20230710100801-03a71d0fca3d
-	{% endif -%}
-	{% endif -%}
-	{% if cookiecutter.terraform_provider_package_name.startswith("internal") -%}
+	{% endif %}
+	{% endif %}
+	{% if cookiecutter.terraform_provider_package_name.startswith("internal") %}
 	{{ cookiecutter.terraform_provider_module }}/shim => ./shim
-	{% endif -%}
+	{% endif %}
 )
 
 require (
 	github.com/ettle/strcase v0.1.1
-	{% if not cookiecutter.terraform_provider_package_name.startswith("internal") -%}
+	{% if not cookiecutter.terraform_provider_package_name.startswith("internal") %}
 	{{ cookiecutter.terraform_provider_module }} {{ cookiecutter.terraform_provider_version_or_commit | go_module_version_tag }}
 	{% endif %}
 )

--- a/{{cookiecutter.provider}}/provider/resources.go
+++ b/{{cookiecutter.provider}}/provider/resources.go
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:generate go run generate.go
 package {{ cookiecutter.terraform_provider_name }}
 
 import (
-	{% if cookiecutter.terraform_sdk_version == "plugin-framework" -%}
+	{% if cookiecutter.terraform_sdk_version == "plugin-framework" %}
 	_ "embed"
-{%- endif %}
+{% endif %}
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -28,25 +29,25 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
-{%- if cookiecutter.terraform_sdk_version != "plugin-framework" %}
-	{% if cookiecutter.terraform_sdk_version == "1" -%}
+{% if cookiecutter.terraform_sdk_version != "plugin-framework" %}
+	{% if cookiecutter.terraform_sdk_version == "1" %}
 	shimv1 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v1"
-	{% else -%}
+	{% else %}
 	shimv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
-	{%- endif %}
-{%- endif %}
-{%- if cookiecutter.terraform_provider_package_name.startswith("internal") %}
+	{% endif %}
+{% endif %}
+{% if cookiecutter.terraform_provider_package_name.startswith("internal") %}
 	shimprovider "{{ cookiecutter.terraform_provider_module }}/shim"
-{%- else %}
+{% else %}
 	"{{ cookiecutter.terraform_provider_module }}/{{ cookiecutter.terraform_provider_package_name }}"
-{%- endif %}
-{%- if cookiecutter.terraform_sdk_version == "plugin-framework" %}
+{% endif %}
+{% if cookiecutter.terraform_sdk_version == "plugin-framework" %}
 	pf "github.com/pulumi/pulumi-terraform-bridge/pf/tfbridge"
-{%- endif %}
+{% endif %}
 	"github.com/{{ cookiecutter.provider_github_organization }}/pulumi-{{ cookiecutter.terraform_provider_name }}/provider/pkg/version"
 )
 
-{% if cookiecutter.terraform_sdk_version == "plugin-framework" -%}
+{% if cookiecutter.terraform_sdk_version == "plugin-framework" %}
 //go:embed cmd/pulumi-resource-{{ cookiecutter.terraform_provider_name }}/bridge-metadata.json
 var bridgeMetadata []byte
 {% endif %}
@@ -85,27 +86,27 @@ func preConfigureCallback(vars resource.PropertyMap, c shim.ResourceConfig) erro
 // Provider returns additional overlaid schema and metadata associated with the provider..
 func Provider() tfbridge.ProviderInfo {
 	// Instantiate the Terraform provider
-	{% if cookiecutter.terraform_sdk_version != "plugin-framework" -%}
-		{% if cookiecutter.terraform_provider_package_name.startswith("internal") -%}
-			{% if cookiecutter.terraform_sdk_version == "1" -%}
+	{% if cookiecutter.terraform_sdk_version != "plugin-framework" %}
+		{% if cookiecutter.terraform_provider_package_name.startswith("internal") %}
+			{% if cookiecutter.terraform_sdk_version == "1" %}
 	p := shimv1.NewProvider(shimprovider.NewProvider())
-			{% else -%}
+			{% else %}
 	p := shimv2.NewProvider(shimprovider.NewProvider())
 			{% endif %}
-		{% else -%}
-			{% if cookiecutter.terraform_sdk_version == "1" -%}
+		{% else %}
+			{% if cookiecutter.terraform_sdk_version == "1" %}
 	p := shimv1.NewProvider({{ cookiecutter.terraform_provider_package_name }}.Provider())
-			{% else -%}
+			{% else %}
 	p := shimv2.NewProvider({{ cookiecutter.terraform_provider_package_name }}.Provider())
 			{% endif %}
-		{%- endif -%}
-	{% else -%}
-		{%- if cookiecutter.terraform_provider_package_name.startswith("internal") -%}
+		{% endif %}
+	{% else %}
+		{% if cookiecutter.terraform_provider_package_name.startswith("internal") %}
 	p := pf.ShimProvider(shimprovider.NewProvider())
-		{%- else -%}
+		{% else %}
 	p := pf.ShimProvider({{ cookiecutter.terraform_provider_package_name }}.NewProvider())
-		{% endif -%}
-	{% endif -%}
+		{% endif %}
+	{% endif %}
 
 	// Create a Pulumi provider mapping
 	prov := tfbridge.ProviderInfo{
@@ -145,9 +146,9 @@ func Provider() tfbridge.ProviderInfo {
 		// should match the TF provider module's require directive, not any replace directives.
 		Version:   version.Version,
 		GitHubOrg: "{{ cookiecutter.terraform_provider_org }}",
-		{% if cookiecutter.terraform_sdk_version == "plugin-framework" -%}
+		{% if cookiecutter.terraform_sdk_version == "plugin-framework" %}
 		MetadataInfo: tfbridge.NewProviderMetadata(bridgeMetadata),
-		{% endif -%}
+		{% endif %}
 		Config:    map[string]*tfbridge.SchemaInfo{
 			// Add any required configuration here, or remove the example below if
 			// no additional points are required.

--- a/{{cookiecutter.provider}}/provider/shim/shim.go
+++ b/{{cookiecutter.provider}}/provider/shim/shim.go
@@ -1,21 +1,21 @@
 package shim
 
-{% if cookiecutter.terraform_sdk_version != "plugin-framework" -%}
+{% if cookiecutter.terraform_sdk_version != "plugin-framework" %}
 import (
-	{% if cookiecutter.terraform_sdk_version == "1" -%}
+	{% if cookiecutter.terraform_sdk_version == "1" %}
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	{% else -%}
+	{% else %}
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	{% endif %}
 	"{{ cookiecutter.terraform_provider_module }}/{{ cookiecutter.terraform_provider_package_name }}"
 )
 
 func NewProvider() *schema.Provider {
-	{% set list = cookiecutter.terraform_provider_package_name.split('/') -%}
+	{% set list = cookiecutter.terraform_provider_package_name.split('/') %}
 	p, _ := {{ list[-1] }}.New()
 	return p
 }
-{% elif cookiecutter.terraform_sdk_version == "plugin-framework" -%}
+{% elif cookiecutter.terraform_sdk_version == "plugin-framework" %}
 import (
 	"{{ cookiecutter.terraform_provider_module }}/{{ cookiecutter.terraform_provider_package_name }}"
 	tf "github.com/hashicorp/terraform-plugin-framework/provider"
@@ -24,4 +24,4 @@ import (
 func NewProvider() tf.Provider {
 		return provider.New()
 }
-{% endif -%}
+{% endif %}


### PR DESCRIPTION
- chore(.pre-commit-config.yaml): updated pre-commit repos
- chore(cookiecutter.json): using lstrip_blocks=true and trim_blocks=true for jinja
- fix(local_extensions.py): moved local extension is_truthy to environment.filters
- chore: removed all manual jinja whitespace controls because whitespace control is centrally set via cookiecutter.json
- chore({{cookiecutter.provider}}/.github/workflows/release.yml): removed jinja whitespace controls
- feat: added {{cookiecutter.provider}}/provider/generate.go
- feat({{cookiecutter.provider}}/provider/resources.go): added link to generate.go for autogenerating resource mappings chore({{cookiecutter.provider}}/provider/resources.go): removed manual jinja whitespace controls
- feat({{cookiecutter.provider}}/Makefile): added target generate
- docs({{cookiecutter.provider}}/README-DEVELOPMENT.md): added table of contents and corrected chapter about CICD integration
- docs(README.md): made the part about how to further develop the created provider stand out as a markdown quote with GitHub info icon

Closes: #31