### PR TITLE
feat: validate GitHub workflows

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     rev: 'v1.35.1'
     hooks:
       - id: 'yamllint'
-        exclude: 'azure-pipelines.yml'
+        exclude: '.github/workflows'
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ cookiecutter
 pre-commit
 ruff
 pytest
+pytest-subtests
 tox

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,8 +1,9 @@
 import hashlib
 import logging
+import pathlib
 import subprocess
 from subprocess import Popen
-from typing import List
+from typing import List, Optional
 
 import pytest
 from cookiecutter.main import cookiecutter
@@ -48,45 +49,70 @@ _logger = logging.getLogger()
 )
 def test_replay_configuration(
     tmp_path_factory,
+    subtests,
     replay_file: str,
     patches: List[str],
 ):
-    md5 = hashlib.md5(replay_file.encode())
-    out_dir = tmp_path_factory.mktemp(md5.hexdigest())
+    project_dir: Optional[str] = None
+    with subtests.test(msg="Creating project"):
+        md5 = hashlib.md5(replay_file.encode())
+        out_dir = tmp_path_factory.mktemp(md5.hexdigest())
 
-    _logger.info("Creating project from template %s at %s", replay_file, out_dir)
+        _logger.debug("Creating project from template %s at %s", replay_file, out_dir)
 
-    project_dir = cookiecutter(
-        template=".",
-        replay=replay_file,
-        output_dir=out_dir,
-    )
+        project_dir = cookiecutter(
+            template=".",
+            replay=replay_file,
+            output_dir=out_dir,
+        )
 
-    for patch in patches or []:
-        with open(patch) as f:
-            _logger.info("Apply patch %s to project in %s", patch, project_dir)
-            git = Popen(
+    assert project_dir
+
+    with subtests.test(msg="Compiling project"):
+        _logger.debug("Compiling project in %s", project_dir)
+
+        for patch in patches or []:
+            with open(patch) as f:
+                _logger.debug("Apply patch %s to project in %s", patch, project_dir)
+
+                git = Popen(
+                    args=[
+                        "git",
+                        "apply",
+                        "--ignore-space-change",
+                        "--ignore-whitespace",
+                    ],
+                    cwd=project_dir,
+                    stdin=f,
+                    stderr=subprocess.PIPE,
+                )
+                git.wait()
+                if git.returncode != 0:
+                    pytest.fail(git.stderr.read().decode())
+
+        make = Popen(
+            args=["make", "provider"],
+            cwd=project_dir,
+            stderr=subprocess.PIPE,
+        )
+        make.wait()
+        if make.returncode != 0:
+            pytest.fail(make.stderr.read().decode())
+
+    with subtests.test(msg="Validate GitHub workflows"):
+        workflows = pathlib.Path(project_dir) / ".github" / "workflows"
+
+        for file in workflows.glob("*.yml"):
+            _logger.debug("Validate GitHub workflow at %s", file)
+
+            action_validator = Popen(
                 args=[
-                    "git",
-                    "apply",
-                    "--ignore-space-change",
-                    "--ignore-whitespace",
+                    "action-validator",
+                    file,
                 ],
                 cwd=project_dir,
-                stdin=f,
                 stderr=subprocess.PIPE,
             )
-            git.wait()
-            if git.returncode != 0:
-                pytest.fail(git.stderr.read().decode())
-
-    _logger.info("Compiling project in %s", project_dir)
-
-    make = Popen(
-        args=["make", "provider"],
-        cwd=project_dir,
-        stderr=subprocess.PIPE,
-    )
-    make.wait()
-    if make.returncode != 0:
-        pytest.fail(make.stderr.read().decode())
+            action_validator.wait()
+            if action_validator.returncode != 0:
+                pytest.fail(action_validator.stderr.read().decode())


### PR DESCRIPTION
This PR contains changes to validate the generated GitHub workflows using action-validator while executing tests.

* chore: added empty examples directory with .gitkeep to keep action-validator happy about paths-ignore settings in the GitHub workflows
* chore: exclude '.github/workflows' from yamllint hook .pre-commit-config.yaml
* chore: add pytest-subtests to requirements.txt
* test: changes to tests/test_main.py